### PR TITLE
文章中的链接尽量跳转到app的内部文章

### DIFF
--- a/lib/Components/Markdown.dart
+++ b/lib/Components/Markdown.dart
@@ -52,7 +52,7 @@ class MMarkdown extends StatelessWidget {
       ),
       onTapLink: (text, href, title) {
         if (href == null || href == '') return;
-        URLUtil.openUrl(href, context);
+        URLUtil.openUrl(href, context, openLocalArtical: true);
       },
     );
   }

--- a/lib/Utils/ArticleUtil.dart
+++ b/lib/Utils/ArticleUtil.dart
@@ -1,0 +1,21 @@
+import 'package:caritas/Models/Db/DbHelper.dart';
+import 'package:hive/hive.dart';
+
+class ArticleUtil {
+  // 有以下链接样式
+  // www.zhihu.com/question/xxxxx/answer/xxxxx
+  // 传入此样式的url, 返回知乎链接包含此url的文章
+  static Article? findArticleByUrl(String url) {
+    url =
+        RegExp(r'www.zhihu.com/question/\d+/answer/\d+').firstMatch(url)?[0] ??
+            "";
+    if (url == "") return null;
+    List<Article> articles = Hive.box("articles").values.toList().cast();
+    for (var article in articles) {
+      if (article.zhihuLink.contains(url)) {
+        return article;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/Utils/URLUtil.dart
+++ b/lib/Utils/URLUtil.dart
@@ -1,10 +1,24 @@
+import 'package:caritas/Pages/Article/ArticleView.dart';
+import 'package:caritas/Utils/ArticleUtil.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:universal_io/io.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class URLUtil {
   static openUrl(String url, BuildContext context,
-      {String? appUrlScheme}) async {
+      {String? appUrlScheme, bool openLocalArtical = false}) async {
+    // 如果链接匹配本地文章, 则跳转到本地文章页面, 而不是知乎页面
+    if (openLocalArtical) {
+      var article = ArticleUtil.findArticleByUrl(url);
+      if (article != null) {
+        await Navigator.of(context).push(CupertinoPageRoute(
+            builder: (BuildContext context) => ArticleView(
+                  article,
+                )));
+        return;
+      }
+    }
 
     /// 试了下，安卓并不能成功调起 schema，只能通过在其他应用中打开链接的方式
     /// 因此只有 iOS 进行自动 schema 识别


### PR DESCRIPTION
如下图中的链接, 将跳转到app中对应的文章, 其他链接或找不到对应文章的则按原来的逻辑跳转
![image](https://user-images.githubusercontent.com/39115813/213687441-e987f46e-683d-4291-96da-f7b4ff5798f6.png)
